### PR TITLE
[MODIFY]설문 저장 업데이트 오류 해결

### DIFF
--- a/components/CreateSurveyDnd/QuestionItems/MultipleChoiceQuestions/index.tsx
+++ b/components/CreateSurveyDnd/QuestionItems/MultipleChoiceQuestions/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { MultipleQuestion } from "@components/CreateSurveyDnd/QuestionItems/MultipleChoiceQuestions/type";
 import { Button, Input } from "antd";
 import {
@@ -25,9 +25,13 @@ export const MultipleChoiceQuestions = (props: subProps) => {
     answers: [""],
     logics: [""],
   });
+
+  useEffect(() => {
+    props.onChange(multipleQuestion);
+  }, [multipleQuestion]);
+
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setMultipleQuestion({ ...multipleQuestion, title: event.target.value });
-    props.onChange(multipleQuestion);
   };
 
   const handleExplainChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -35,7 +39,6 @@ export const MultipleChoiceQuestions = (props: subProps) => {
       ...multipleQuestion,
       explanation: event.target.value,
     });
-    props.onChange(multipleQuestion);
   };
 
   const handleOptionChange = (
@@ -45,20 +48,17 @@ export const MultipleChoiceQuestions = (props: subProps) => {
     const newOptions = [...multipleQuestion.answers];
     newOptions[optionIndex] = event.target.value;
     setMultipleQuestion({ ...multipleQuestion, answers: newOptions });
-    props.onChange(multipleQuestion);
   };
 
   const handleAddOption = () => {
     const newOptions = [...multipleQuestion.answers, ""];
     setMultipleQuestion({ ...multipleQuestion, answers: newOptions });
-    props.onChange(multipleQuestion);
   };
 
   const handleDeleteOption = (optionIndex: number) => {
     const newOptions = [...multipleQuestion.answers];
     newOptions.splice(optionIndex, 1);
     setMultipleQuestion({ ...multipleQuestion, answers: newOptions });
-    props.onChange(multipleQuestion);
   };
 
   return (

--- a/components/CreateSurveyDnd/QuestionItems/RangeBarQuestions/index.tsx
+++ b/components/CreateSurveyDnd/QuestionItems/RangeBarQuestions/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { RangeBarQuestion } from "@components/CreateSurveyDnd/QuestionItems/RangeBarQuestions/type";
 import { Input, InputNumber, Slider } from "antd";
 import {
@@ -23,26 +23,27 @@ export const RangeBarQuestions = (props: subProps) => {
     max: 5,
   });
 
+  useEffect(() => {
+    props.onChange(rangeBarQuestions);
+  }, [rangeBarQuestions]);
+
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRangeBarQuestions({
       ...rangeBarQuestions,
       title: event.target.value,
     });
-    props.onChange(rangeBarQuestions);
   };
   const handleExplainChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setRangeBarQuestions({
       ...rangeBarQuestions,
       explanation: event.target.value,
     });
-    props.onChange(rangeBarQuestions);
   };
   const handleRangeChange = (newValue: number) => {
     setRangeBarQuestions({
       ...rangeBarQuestions,
       value: newValue,
     });
-    props.onChange(rangeBarQuestions);
   };
   const handleMinChange = (value: number | null) => {
     if (value != null) {
@@ -50,7 +51,6 @@ export const RangeBarQuestions = (props: subProps) => {
         ...rangeBarQuestions,
         min: value,
       });
-      props.onChange(rangeBarQuestions);
     }
   };
 

--- a/components/CreateSurveyDnd/QuestionItems/SubjectiveQuestions/index.tsx
+++ b/components/CreateSurveyDnd/QuestionItems/SubjectiveQuestions/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { SubjectiveQuestion } from "@components/CreateSurveyDnd/QuestionItems/SubjectiveQuestions/type";
 import { Button, Input } from "antd";
 import {
@@ -22,19 +22,21 @@ export const SubjectiveQuestions = (props: subProps) => {
       finalQuestion: false,
       nextQuestionNumber: "0",
     });
+
+  useEffect(() => {
+    props.onChange(subjectiveQuestions);
+  }, [subjectiveQuestions]);
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSubjectiveQuestions({
       ...subjectiveQuestions,
       title: event.target.value,
     });
-    props.onChange(subjectiveQuestions);
   };
   const handleExplainChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSubjectiveQuestions({
       ...subjectiveQuestions,
       explanation: event.target.value,
     });
-    props.onChange(subjectiveQuestions);
   };
 
   return (


### PR DESCRIPTION
하위 컴포넌트에서 상위 컴포넌트의 useState를 props를 통해 수정 및 추가할 때, 상위 컴포넌트의 state가 업데이트 되기 전에 하위 컴포넌트에서 수정된 값을 사용하고 있었다.
이 문제를 해결하기 위해서, 하위 컴포넌트에서 직접 props의 useCallBack 함수를 실행하는 것이 아니라 useEffect를 통해 하위 컴포넌트 자체에서 변수를 관리하고, 변동 시 props.onChange로 상위 컴포넌트에게 전달했다.