### PR TITLE
[ADD]Main,Header테스트 추가

### DIFF
--- a/components/MainComponent/MainFirst/index.tsx
+++ b/components/MainComponent/MainFirst/index.tsx
@@ -60,16 +60,15 @@ const MainFirst = () => {
           Cocoa
           <br />
         </Text>
-        <Link
-          to="/createsurvey"
-          onClick={handleClick}
-          style={{ textDecoration: "none" }}
-        >
-          <Button>
+        <Button>
+          <Link
+            to="/createsurvey"
+            onClick={handleClick}
+            style={{ textDecoration: "none" }}
+          >
             Get Start
-            <br />
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       </TextDiv>
     </Wrapper>
   );

--- a/cypress/e2e/1.header_bar/header_bar.cy.ts
+++ b/cypress/e2e/1.header_bar/header_bar.cy.ts
@@ -1,24 +1,49 @@
 describe("Header", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+  context("헤더 바의 사이트 제목은 Cocoa여야 한다.", () => {
+    it("헤더 바 제목", () => {
+      cy.get(".css-64wk4k").should("be.visible").should("have.text", "Cocoa");
+    });
+  });
   context(
-    "헤더 바의 메뉴들은 링크를 가지고 있어야 하며, 각 링크의 페이지는 유효해야 한다.",
+    "헤더 바의 메뉴들은 유효한 링크를 가지고 있어야 하며, 각 링크는 메뉴 구성과 같아야 한다.",
     () => {
       it("네비게이션 요소", () => {
-        cy.visit("/");
+        const menuItems = ["Product", "Team", "MY PAGE", "Login", "Get Start"];
         cy.get(".css-120oq2b")
           .find("span")
           .each(($span, index) => {
             const text = $span.text(); // <span>의 텍스트 가져오기
+            const menuItemName = menuItems[index];
             if (text.includes("http")) {
-              cy.wrap($span).should("have.attr", "href");
+              cy.wrap($span)
+                .should("have.attr", "href")
+                .should("contain.text", menuItemName);
             }
           });
       });
     }
   );
-  context("헤더 바의 사이트 제목은 Cocoa여야 한다.", () => {
-    it("헤더 바 제목", () => {
-      cy.visit("/");
-      cy.get(".css-64wk4k").should("be.visible").should("have.text", "Cocoa");
-    });
-  });
+  context(
+    "localStorage에 사용자 accessToken이 존재하면 Logout이어야 하고, 아니면 Login이어야 한다.",
+    () => {
+      it("로그인 텍스트", () => {
+        cy.window().then((win) => {
+          const accessToken = win.localStorage.getItem("accessToken");
+          // mockAccessToken으로 테스트 가능
+          if (accessToken === "accessToken") {
+            cy.get(":nth-child(4) > a")
+              .should("be.visible")
+              .should("have.text", "Logout");
+          } else {
+            cy.get(":nth-child(4) > a")
+              .should("be.visible")
+              .should("have.text", "Login");
+          }
+        });
+      });
+    }
+  );
 });

--- a/cypress/e2e/2.main_page/main_page.cy.ts
+++ b/cypress/e2e/2.main_page/main_page.cy.ts
@@ -1,1 +1,57 @@
-describe("Main Page", () => {});
+describe("Main", () => {
+  beforeEach(() => {
+    // test를 위해 accessToken이 있다고 가정한다.
+    cy.visit("/", {
+      onBeforeLoad: (win) => {
+        win.localStorage.setItem("accessToken", "mockAccessToken");
+      },
+    });
+  });
+  context("메인 페이지의 가이드 텍스트는 유효하며 보여야한다.", () => {
+    it("메인 페이지 텍스트 요소", () => {
+      cy.get(".css-e467n0 > .css-1e91d6q > :nth-child(1)")
+        .should("be.visible")
+        .should("have.text", "업무를 빠르고 쉽게");
+      cy.get(".css-e467n0 > .css-1e91d6q > :nth-child(2)")
+        .should("be.visible")
+        .should("have.text", "Cocoa");
+      cy.get(".css-0 > .css-1e91d6q > .css-6khpng")
+        .should("be.visible")
+        .should("have.text", "드래그 앤 드롭으로 쉽게");
+      cy.get(".css-1lr4xyl")
+        .should("be.visible")
+        .should("have.text", "쉽고 빠르게 설문을 시작하세요!");
+      cy.get(".css-1edcj4h > .css-1e91d6q > .css-6khpng").should("be.visible");
+      cy.get(".css-1edcj4h > .css-1e91d6q > :nth-child(2)").should(
+        "be.visible"
+      );
+      cy.get(".css-1edcj4h > .css-1e91d6q > :nth-child(3)").should(
+        "be.visible"
+      );
+      // cy.scrollTo("bottom", { duration: 2000 });
+      // cy.scrollTo("top", { duration: 2000 });
+    });
+  });
+  context(
+    "메인페이지의 Get Start 버튼은 로그인 상태 시 설문생성으로 이동해야한다.",
+    () => {
+      it("메인 페이지 Get Start 버튼", () => {
+        // localStorage를 확인해서 로그인 상태인지 확인
+        cy.window().then((win) => {
+          const accessToken = win.localStorage.getItem("accessToken");
+          // mockAccessToken으로 테스트 가능
+          if (accessToken === "accessToken") {
+            cy.get(".ant-btn > a")
+              .should("exist")
+              .and("contain.text", "Get Start")
+              .click({ force: true });
+            cy.url().should("include", "/createsurvey");
+            cy.get(".css-64wk4k").click();
+          } else {
+            cy.log("no accessToken");
+          }
+        });
+      });
+    }
+  );
+});


### PR DESCRIPTION
- Header
헤더 바의 사이트 제목은 Cocoa여야 한다.
헤더 바의 메뉴들은 유효한 링크를 가지고 있어야 하며, 각 링크는 메뉴 구성과 같아야 한다.
localStorage에 사용자 accessToken이 존재하면 Logout이어야 하고, 아니면 Login이어야 한다.

- Main
메인 페이지의 가이드 텍스트는 유효하며 보여야한다.
메인페이지의 Get Start 버튼은 로그인 상태 시 설문생성으로 이동해야한다.

- 추가
main_page.cy.ts에 accessToken을 mockAccessToken으로 setItem하는 BeforeEach(onBeforeLoad) 코드 추가. accessToken 테스트를 확인하려면 accessToken을 mockAccessToken으로 변환 후 테스트 진행.
  ```
  beforeEach(() => {
      // test를 위해 accessToken이 있다고 가정한다.
      cy.visit("/", {
        onBeforeLoad: (win) => {
          win.localStorage.setItem("accessToken", "mockAccessToken");
        },
      });
    });
  ```